### PR TITLE
add full class package name for run JVM (desktop-compose-app)

### DIFF
--- a/desktop-compose-app/build.gradle.kts
+++ b/desktop-compose-app/build.gradle.kts
@@ -40,7 +40,7 @@ compose {
     kotlinCompilerPlugin.set("1.4.8")
     desktop {
         application {
-            mainClass = "MainKt"
+            mainClass = "com.softartdev.notedelight.MainKt"
             nativeDistributions {
                 targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
                 packageName = "com.softartdev.notedelight"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ minSdk = "21"
 
 kotlin = "1.8.22"
 coroutines = "1.7.2"
-sqlDelight = "2.0.0-rc02"
+sqlDelight = "2.0.0"
 androidxSqlite = "2.3.1"
 saferoom = "1.3.0"
 androidSqlCipher = "4.5.4"


### PR DESCRIPTION
at my env (OSX & Windows)  run "desktop-compose-app" fail !!

because lost full  package name !!

so i modify   mainClass = "MainKt" -->  mainClass = "com.softartdev.notedelight.MainKt"

PS.  can  add new  JVM -subproject ?  demo ktor sever with sqlite DB to save Note  ? 

THX