### PR TITLE
Fix edit title crash -- issue 416

### DIFF
--- a/desktop-compose-app/build.gradle.kts
+++ b/desktop-compose-app/build.gradle.kts
@@ -40,7 +40,7 @@ compose {
     kotlinCompilerPlugin.set("1.4.8")
     desktop {
         application {
-            mainClass = "MainKt"
+            mainClass = "com.softartdev.notedelight.MainKt"
             nativeDistributions {
                 targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
                 packageName = "com.softartdev.notedelight"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ minSdk = "21"
 
 kotlin = "1.8.22"
 coroutines = "1.7.2"
-sqlDelight = "2.0.0-rc02"
+sqlDelight = "2.0.0"
 androidxSqlite = "2.3.1"
 saferoom = "1.3.0"
 androidSqlCipher = "4.5.4"

--- a/shared-compose-ui/src/commonMain/kotlin/com/softartdev/notedelight/ui/NoteDetail.kt
+++ b/shared-compose-ui/src/commonMain/kotlin/com/softartdev/notedelight/ui/NoteDetail.kt
@@ -63,7 +63,7 @@ fun NoteDetail(
             val noteSaved = MR.strings.note_saved.contextLocalized() + ": " + noteResult.title
             snackbarHostState.showSnackbar(noteSaved)
         }
-        is NoteResult.NavEditTitle -> dialogHolder.showEditTitle(noteId)
+        is NoteResult.NavEditTitle -> dialogHolder.showEditTitle(noteResult.noteId)
         is NoteResult.TitleUpdated -> {
             titleState.value = noteResult.title
         }


### PR DESCRIPTION
Dear Sir

After adding a Node
Immediately click the upper "T" to execute the action of editing Title
Crash will occur on Desktop (Windows/Mac)
The reason is that the incoming noteid is incorrect  --> dialogHolder.showEditTitle(noteId)


Can't find the corresponding Note  --> loadNote can not return null !!

so must change to "dialogHolder.showEditTitle(noteResult.noteId)" 

https://github.com/softartdev/NoteDelight/issues/416

THX