### PR TITLE
modify insert new Note -- How check insert result ?

### DIFF
--- a/desktop-compose-app/build.gradle.kts
+++ b/desktop-compose-app/build.gradle.kts
@@ -40,7 +40,7 @@ compose {
     kotlinCompilerPlugin.set("1.4.8")
     desktop {
         application {
-            mainClass = "MainKt"
+            mainClass = "com.softartdev.notedelight.MainKt"
             nativeDistributions {
                 targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
                 packageName = "com.softartdev.notedelight"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ minSdk = "21"
 
 kotlin = "1.8.22"
 coroutines = "1.7.2"
-sqlDelight = "2.0.0-rc02"
+sqlDelight = "2.0.0"
 androidxSqlite = "2.3.1"
 saferoom = "1.3.0"
 androidSqlCipher = "4.5.4"

--- a/shared-compose-ui/src/commonMain/kotlin/com/softartdev/notedelight/ui/NoteDetail.kt
+++ b/shared-compose-ui/src/commonMain/kotlin/com/softartdev/notedelight/ui/NoteDetail.kt
@@ -63,7 +63,7 @@ fun NoteDetail(
             val noteSaved = MR.strings.note_saved.contextLocalized() + ": " + noteResult.title
             snackbarHostState.showSnackbar(noteSaved)
         }
-        is NoteResult.NavEditTitle -> dialogHolder.showEditTitle(noteId)
+        is NoteResult.NavEditTitle -> dialogHolder.showEditTitle(noteResult.noteId)
         is NoteResult.TitleUpdated -> {
             titleState.value = noteResult.title
         }

--- a/shared/src/commonMain/kotlin/com/softartdev/notedelight/shared/database/DatabaseSchema.kt
+++ b/shared/src/commonMain/kotlin/com/softartdev/notedelight/shared/database/DatabaseSchema.kt
@@ -37,6 +37,7 @@ object TestSchema {
         dateModified = LocalDateTime(2016, 2, 3, 4, 5),
     )
 
-    fun insertTestNotes(noteQueries: NoteQueries) =
-        sequenceOf(firstNote, secondNote, thirdNote).forEach(noteQueries::insert)
+    //FIXME
+//    fun insertTestNotes(noteQueries: NoteQueries) =
+//        sequenceOf(firstNote, secondNote, thirdNote).forEach(noteQueries::insert)
 }

--- a/shared/src/commonMain/sqldelight/com/softartdev/notedelight/shared/db/Note.sq
+++ b/shared/src/commonMain/sqldelight/com/softartdev/notedelight/shared/db/Note.sq
@@ -14,8 +14,12 @@ SELECT * FROM note ORDER BY dateModified DESC;
 getById:
 SELECT * FROM note WHERE id = :noteId;
 
-insert:
-INSERT INTO note VALUES ?;
+-- Ref : https://github.com/cashapp/sqldelight/issues/1482
+-- Ref : https://github.com/cashapp/sqldelight/issues/4508#issuecomment-1672976163
+insert{
+      INSERT INTO note( title,text ,dateCreated,dateModified) VALUES ( ?,?,?,?  );
+      SELECT last_insert_rowid();
+}
 
 lastInsertRowId:
 SELECT last_insert_rowid();


### PR DESCRIPTION
Dear Sir

I'm an Android engineer

In the past, SQLite was used for operations (before Google launched ROOM)

When inserting data, the insert result will be judged

For example

https://stackoverflow.com/questions/27863609/android-sqlite-check-if-inserted-new-value

Also looking for a similar part while using sqldelight

Because you set the id of Note to "PRIMARY KEY AUTOINCREMENT"

There should be no need to bring noteid here

So after I searched for the article

https://github.com/cashapp/sqldelight/issues/1482

https://github.com/cashapp/sqldelight/issues/4508#issuecomment-1672976163

Made some changes to the insert part

What do you think?

Thanks 