### PR TITLE
Desktop SQLCipher check error

### DIFF
--- a/core/data/db-sqldelight/src/jvmMain/kotlin/com/softartdev/notedelight/db/JdbcDatabaseHolder.kt
+++ b/core/data/db-sqldelight/src/jvmMain/kotlin/com/softartdev/notedelight/db/JdbcDatabaseHolder.kt
@@ -62,19 +62,20 @@ class JdbcDatabaseHolder(props: Properties = Properties()) : SqlDelightDbHolder 
         }
 
         /**
-         * Creates a JDBC driver with optional SQLCipher encryption.
-         * 
+         * Builds a JDBC URL for the SQLite database, optionally with SQLCipher encryption.
+         *
          * Uses Willena's sqlite-jdbc-crypt library which provides SQLCipher support
-         * through SQLite3 Multiple Ciphers.
-         * 
-         * The encryption is configured via the JDBC URL with parameters:
-         * - `cipher=sqlcipher` - Use SQLCipher encryption
-         * - `legacy=4` - Use SQLCipher version 4 format
-         * - `key=password` - The encryption passphrase
-         * 
-         * @param url The database file path (absolute path)
-         * @param password Optional encryption password. If provided, the database will be encrypted.
-         * @return A SqlDriver instance
+         * through SQLite3 Multiple Ciphers (sqlite3mc).
+         *
+         * For encrypted databases the URL includes query parameters:
+         * - `cipher=sqlcipher` – selects the SQLCipher cipher scheme
+         * - `legacy=4` – SQLCipher version 4 compatibility mode
+         * - `key=<password>` – the encryption passphrase (URL-encoded)
+         *
+         * @param dbPath absolute path to the database file
+         * @param props  JDBC properties; if a `password` entry is present and non-empty
+         *               the returned URL will contain encryption parameters
+         * @return a JDBC URL string ready for [java.sql.DriverManager.getConnection]
          */
         fun buildJdbcUrl(dbPath: String, props: Properties): String {
             val logger = Logger.withTag("JdbcDatabaseHolder")

--- a/core/data/db-sqldelight/src/jvmMain/kotlin/com/softartdev/notedelight/db/JdbcDatabaseHolder.kt
+++ b/core/data/db-sqldelight/src/jvmMain/kotlin/com/softartdev/notedelight/db/JdbcDatabaseHolder.kt
@@ -13,8 +13,9 @@ import java.util.Properties
 class JdbcDatabaseHolder(props: Properties = Properties()) : SqlDelightDbHolder {
     private val logger = Logger.withTag(this@JdbcDatabaseHolder::class.simpleName.toString())
     private val dbPath = FilePathResolver().invoke()
-    
-    override val driver: SqlDriver = createDriver(dbPath, props)
+
+    val jdbcUrl: String = buildJdbcUrl(dbPath, props)
+    override val driver: SqlDriver = createDriver(jdbcUrl, props)
     override val noteDb: NoteDb = createQueryWrapper(driver)
     override val noteQueries = noteDb.noteQueries
 
@@ -75,23 +76,29 @@ class JdbcDatabaseHolder(props: Properties = Properties()) : SqlDelightDbHolder 
          * @param password Optional encryption password. If provided, the database will be encrypted.
          * @return A SqlDriver instance
          */
-        private fun createDriver(url: String, props: Properties): SqlDriver {
+        fun buildJdbcUrl(dbPath: String, props: Properties): String {
             val logger = Logger.withTag("JdbcDatabaseHolder")
             val password: String? = props.getProperty("password")
-            val jdbcUrl = if (password.isNullOrEmpty()) {
-                // Unencrypted database - use standard SQLDelight format
-                val unencryptedUrl = JdbcSqliteDriver.IN_MEMORY + url
+            return if (password.isNullOrEmpty()) {
+                val unencryptedUrl = JdbcSqliteDriver.IN_MEMORY + dbPath
                 logger.d { "Creating unencrypted driver with URL: $unencryptedUrl" }
                 unencryptedUrl
             } else {
-                // Build encrypted JDBC URL with SQLCipher parameters
-                // sqlite-jdbc-crypt uses "jdbc:sqlite:file:" prefix for encrypted databases
                 val encodedPassword = URLEncoder.encode(password, StandardCharsets.UTF_8)
-                val encryptedUrl = "$JDBC_PREFIX_ENCRYPTED$url?cipher=$SQLCIPHER_CIPHER&legacy=$SQLCIPHER_LEGACY&key=$encodedPassword"
+                val encryptedUrl = "$JDBC_PREFIX_ENCRYPTED$dbPath?cipher=$SQLCIPHER_CIPHER&legacy=$SQLCIPHER_LEGACY&key=$encodedPassword"
                 logger.d { "Creating encrypted driver with URL: $encryptedUrl (password length: ${password.length})" }
                 encryptedUrl
             }
-            return JdbcSqliteDriver(jdbcUrl, props)
+        }
+
+        private fun createDriver(jdbcUrl: String, props: Properties): SqlDriver {
+            val driverProps = Properties()
+            for (key in props.stringPropertyNames()) {
+                if (key != "password") {
+                    driverProps.setProperty(key, props.getProperty(key))
+                }
+            }
+            return JdbcSqliteDriver(jdbcUrl, driverProps)
         }
     }
 }

--- a/core/data/db-sqldelight/src/jvmMain/kotlin/com/softartdev/notedelight/repository/JvmSafeRepo.kt
+++ b/core/data/db-sqldelight/src/jvmMain/kotlin/com/softartdev/notedelight/repository/JvmSafeRepo.kt
@@ -1,7 +1,6 @@
 package com.softartdev.notedelight.repository
 
-import app.cash.sqldelight.db.QueryResult
-import app.cash.sqldelight.db.SqlCursor
+import co.touchlab.kermit.Logger
 import com.softartdev.notedelight.db.FilePathResolver
 import com.softartdev.notedelight.db.JdbcDatabaseHolder
 import com.softartdev.notedelight.db.JvmCipherUtils
@@ -9,6 +8,7 @@ import com.softartdev.notedelight.db.NoteDAO
 import com.softartdev.notedelight.db.SqlDelightNoteDAO
 import com.softartdev.notedelight.model.PlatformSQLiteState
 import com.softartdev.notedelight.util.CoroutineDispatchers
+import java.sql.DriverManager
 import java.util.Properties
 
 class JvmSafeRepo(private val coroutineDispatchers: CoroutineDispatchers) : SafeRepo() {
@@ -51,19 +51,43 @@ class JvmSafeRepo(private val coroutineDispatchers: CoroutineDispatchers) : Safe
     }
 
     override suspend fun execute(query: String): String? {
-        val queryResult: QueryResult<String?> = buildDbIfNeed().driver.executeQuery(
-            identifier = null,
-            sql = query,
-            parameters = 0,
-            binders = null,
-            mapper = this::map
-        )
-        return queryResult.await()
+        val holder = buildDbIfNeed()
+        val url = holder.jdbcUrl
+        val props = Properties()
+        var connection: java.sql.Connection? = null
+        try {
+            connection = DriverManager.getConnection(url, props)
+            val stmt = connection.createStatement()
+            val hasResultSet = stmt.execute(query)
+            val result = if (hasResultSet) {
+                val rs = stmt.resultSet
+                if (rs.next()) rs.getString(1) else null
+            } else {
+                null
+            }
+            stmt.close()
+            if (result != null) return result
+            val mcStmt = connection.createStatement()
+            val mcHasResult = mcStmt.execute(SQLITE3MC_VERSION_QUERY)
+            val mcResult = if (mcHasResult) {
+                val rs = mcStmt.resultSet
+                if (rs.next()) rs.getString(1) else null
+            } else {
+                null
+            }
+            mcStmt.close()
+            return mcResult
+        } catch (e: Exception) {
+            Logger.withTag("JvmSafeRepo").e(e) { "Error executing query: $query" }
+            throw e
+        } finally {
+            connection?.close()
+        }
     }
 
-    private fun map(sqlCursor: SqlCursor): QueryResult<String?> = QueryResult.Value(
-        value = if (sqlCursor.next().value) sqlCursor.getString(0) else null
-    )
+    companion object {
+        private const val SQLITE3MC_VERSION_QUERY = "SELECT sqlite3mc_version();"
+    }
 
     override suspend fun encrypt(newPass: CharSequence) {
         closeDatabase()

--- a/core/data/db-sqldelight/src/jvmMain/kotlin/com/softartdev/notedelight/repository/JvmSafeRepo.kt
+++ b/core/data/db-sqldelight/src/jvmMain/kotlin/com/softartdev/notedelight/repository/JvmSafeRepo.kt
@@ -68,7 +68,7 @@ class JvmSafeRepo(private val coroutineDispatchers: CoroutineDispatchers) : Safe
             stmt.close()
             if (result != null) return result
             val mcStmt = connection.createStatement()
-            val mcHasResult = mcStmt.execute(SQLITE3MC_VERSION_QUERY)
+            val mcHasResult = mcStmt.execute("SELECT sqlite3mc_version();")
             val mcResult = if (mcHasResult) {
                 val rs = mcStmt.resultSet
                 if (rs.next()) rs.getString(1) else null
@@ -83,10 +83,6 @@ class JvmSafeRepo(private val coroutineDispatchers: CoroutineDispatchers) : Safe
         } finally {
             connection?.close()
         }
-    }
-
-    companion object {
-        private const val SQLITE3MC_VERSION_QUERY = "SELECT sqlite3mc_version();"
     }
 
     override suspend fun encrypt(newPass: CharSequence) {

--- a/docs/OPEN_EXPORTED_DB.md
+++ b/docs/OPEN_EXPORTED_DB.md
@@ -1,0 +1,68 @@
+# Opening an Exported Encrypted Database in DB Browser for SQLite
+
+NoteDelight encrypts its database using [SQLite3 Multiple Ciphers](https://utelle.github.io/SQLite3MultipleCiphers/) (sqlite3mc) in **SQLCipher v4 compatibility mode**. Exported `.db` files can be inspected with any tool that supports SQLCipher 4.
+
+## Prerequisites
+
+| Tool | Minimum version | Notes |
+|------|----------------|-------|
+| [DB Browser for SQLite](https://sqlitebrowser.org/dl/) | 3.12.x | Must be a build **with SQLCipher support**. The default Linux package (`apt install sqlitebrowser`) usually ships without it — use the official AppImage or macOS / Windows installer instead. |
+| **or** `sqlcipher` CLI | 4.x | `apt install sqlcipher` (Linux) / `brew install sqlcipher` (macOS) |
+
+> **Tip:** Run `sqlitebrowser --version` — the output should mention **SQLCipher**. If it only shows a plain SQLite version the build does not support encrypted databases.
+
+## Export the database from NoteDelight
+
+1. Open the desktop app and sign in with your password.
+2. Go to **Settings → Backup → Export database**.
+3. Choose a destination path and click **Save**.
+
+The exported file is an exact copy of the encrypted database.
+
+## Open in DB Browser for SQLite
+
+1. Launch **DB Browser for SQLite** (the SQLCipher-enabled build).
+2. **File → Open Database…** and select the exported `.db` file.
+3. A **"SQLCipher encryption"** dialog appears.
+4. Configure the dialog:
+
+| Field | Value |
+|-------|-------|
+| **Password** | Your NoteDelight password |
+| **Encryption settings** | **SQLCipher 4 defaults** |
+| Page size | 4096 |
+| KDF iterations | 256000 |
+| HMAC algorithm | SHA512 |
+| KDF algorithm | SHA512 |
+| Plaintext Header Size | 0 |
+
+5. Click **OK**. The database structure and data should now be visible.
+
+## Open with the `sqlcipher` CLI
+
+```bash
+sqlcipher /path/to/notes.db
+sqlite> PRAGMA key = 'your_password';
+sqlite> .tables
+note  sqlite_sequence
+sqlite> SELECT * FROM note;
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| "file is not a database" after entering password | Verify you selected **SQLCipher 4 defaults** (not SQLCipher 3 or Custom). |
+| DB Browser doesn't show an encryption dialog | You are running a build without SQLCipher. Download the AppImage from the [official releases](https://github.com/sqlitebrowser/sqlitebrowser/releases). |
+| `sqlcipher` CLI says "Error: file is not a database" | Make sure `PRAGMA key` is the **first** statement executed on the connection. |
+
+## Platform differences
+
+| Platform | Encryption library | `PRAGMA cipher_version` result |
+|----------|-------------------|-------------------------------|
+| Android | SQLCipher (Zetetic) | e.g. `4.6.1 community` |
+| iOS | SQLCipher (CocoaPod) | e.g. `4.5.5 community` |
+| Desktop (JVM) | SQLite3 Multiple Ciphers | e.g. `SQLite3 Multiple Ciphers 2.2.7` |
+| Web | sql.js (no encryption) | N/A |
+
+All platforms that support encryption produce databases compatible with the **SQLCipher 4** format.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SQLCipher version check on JVM by resolving JDBC password conflict and adapting cipher query.

The `password` property in `Properties` conflicted with the `key` parameter in the JDBC URL for `sqlite-jdbc-crypt`, causing `[SQLITE_NOTADB]` errors, especially with `ThreadedConnectionManager`. Additionally, `PRAGMA cipher_version;` is not supported by `SQLite3 Multiple Ciphers` (sqlite3mc), requiring a fallback to `SELECT sqlite3mc_version()` via a direct JDBC connection.

---
<p><a href="https://cursor.com/agents/bc-75957d67-cfbf-4fcd-bab0-3939beea5ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75957d67-cfbf-4fcd-bab0-3939beea5ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->