### PR TITLE
Cross-platform backup verification

### DIFF
--- a/core/data/db-sqldelight/src/wasmJsMain/kotlin/com/softartdev/notedelight/db/WebDatabaseHolder.kt
+++ b/core/data/db-sqldelight/src/wasmJsMain/kotlin/com/softartdev/notedelight/db/WebDatabaseHolder.kt
@@ -15,14 +15,18 @@ class WebDatabaseHolder(private val key: String? = null) : SqlDelightDbHolder {
     override val noteQueries: NoteQueries = noteDb.noteQueries
 
     /**
-     * Sets the encryption key on the database connection.
+     * Configures SQLCipher v4 compatibility and sets the encryption key.
      * Must be called BEFORE any other SQL operations (including createSchema).
-     * This sends PRAGMA key as the first statement to the worker.
+     *
+     * Uses `cipher=sqlcipher` with `legacy=4` to match the Desktop JVM and Android
+     * encryption format, enabling cross-platform encrypted backup portability.
      */
     suspend fun applyKey() {
         if (!key.isNullOrEmpty()) {
             val escapedKey = key.replace("'", "''")
-            logger.d { "Setting encryption key on database" }
+            logger.d { "Configuring SQLCipher v4 and setting encryption key" }
+            driver.execute(null, "PRAGMA cipher = 'sqlcipher'", 0, null).await()
+            driver.execute(null, "PRAGMA legacy = 4", 0, null).await()
             driver.execute(null, "PRAGMA key = '$escapedKey'", 0, null).await()
         }
     }

--- a/core/data/db-sqldelight/src/wasmJsMain/kotlin/com/softartdev/notedelight/repository/WebSafeRepo.kt
+++ b/core/data/db-sqldelight/src/wasmJsMain/kotlin/com/softartdev/notedelight/repository/WebSafeRepo.kt
@@ -76,7 +76,8 @@ class WebSafeRepo(private val coroutineDispatchers: CoroutineDispatchers) : Safe
         logger.d { "Encrypting database" }
         val holder = dbHolder ?: buildDbIfNeed()
         val escapedKey = newPass.toString().replace("'", "''")
-        // On an unencrypted database, PRAGMA rekey encrypts it in-place
+        holder.driver.execute(null, "PRAGMA cipher = 'sqlcipher'", 0, null).await()
+        holder.driver.execute(null, "PRAGMA legacy = 4", 0, null).await()
         holder.driver.execute(null, "PRAGMA rekey = '$escapedKey'", 0, null).await()
         logger.d { "PRAGMA rekey executed, closing and reopening with key" }
         closeDatabase()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix encrypted database cross-platform incompatibility between Desktop JVM and Web WASM.

The Desktop JVM uses SQLCipher v4 mode, but the Web WASM was using sqlite3mc's default cipher, leading to "Incorrect password" errors when importing encrypted backups from Desktop to Web. This PR configures the Web WASM to also use SQLCipher v4 mode for consistent encryption across platforms.

---
<p><a href="https://cursor.com/agents/bc-1886e8c2-2138-4715-bde0-3bc675237288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1886e8c2-2138-4715-bde0-3bc675237288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->