### PR TITLE
Jvm app version

### DIFF
--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -10,6 +10,19 @@ plugins {
 apply(from = "$rootDir/gradle/common-desktop-mac-sign-conf.gradle")
 group = "com.softartdev"
 
+val desktopVersion = "8.5.2"
+
+val generateVersionProperties = tasks.register("generateVersionProperties") {
+    val outputDir = layout.buildDirectory.dir("generated/desktop-version")
+    val version = desktopVersion
+    outputs.dir(outputDir)
+    doLast {
+        val outputFile = outputDir.get().file("version.properties").asFile
+        outputFile.parentFile.mkdirs()
+        outputFile.writeText("version=$version")
+    }
+}
+
 kotlin {
     jvm {
         compilerOptions.jvmTarget = JvmTarget.fromTarget(libs.versions.jdk.get())
@@ -46,6 +59,17 @@ kotlin {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")
         }
+        getByName("jvmMain").resources.srcDir(layout.buildDirectory.dir("generated/desktop-version"))
+    }
+}
+
+tasks.named("jvmProcessResources") {
+    dependsOn(generateVersionProperties)
+}
+
+tasks.named<org.gradle.api.tasks.bundling.Jar>("jvmJar") {
+    manifest {
+        attributes("Implementation-Version" to desktopVersion)
     }
 }
 
@@ -55,7 +79,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Note Delight"
-            packageVersion = "8.5.2"
+            packageVersion = desktopVersion
             description = "Note app with encryption"
             copyright = "© 2023 SoftArtDev"
             macOS.iconFile.set(project.file("src/jvmMain/resources/app_icon.icns"))

--- a/core/domain/src/jvmMain/kotlin/com/softartdev/notedelight/usecase/settings/AppVersionUseCase.jvm.kt
+++ b/core/domain/src/jvmMain/kotlin/com/softartdev/notedelight/usecase/settings/AppVersionUseCase.jvm.kt
@@ -1,13 +1,27 @@
 package com.softartdev.notedelight.usecase.settings
 
 import co.touchlab.kermit.Logger
+import java.util.Properties
 
 actual class AppVersionUseCase {
     private val logger = Logger.withTag("AppVersionUseCase")
 
     actual operator fun invoke(): String? {
-        val pkg: Package? = ClassLoader.getSystemClassLoader().getDefinedPackage("com.softartdev.notedelight")
-        logger.i(message = pkg::toString)
-        return pkg?.implementationVersion?.takeIf(String::isNotBlank)
+        val fromManifest = runCatching {
+            val classLoader = AppVersionUseCase::class.java.classLoader ?: ClassLoader.getSystemClassLoader()
+            classLoader.getDefinedPackage("com.softartdev.notedelight")?.implementationVersion
+        }.getOrNull()?.takeIf(String::isNotBlank)
+        if (fromManifest != null) return fromManifest
+
+        val fromProperties = runCatching {
+            (AppVersionUseCase::class.java.classLoader ?: ClassLoader.getSystemClassLoader())
+                .getResourceAsStream("version.properties")?.use { stream ->
+                    Properties().apply { load(stream) }.getProperty("version")?.trim()
+                }
+        }.getOrNull()?.takeIf(String::isNotBlank)
+        if (fromProperties != null) return fromProperties
+
+        logger.w { "App version not found in manifest or version.properties" }
+        return null
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix `AppVersionUseCase.jvm.kt` to correctly retrieve the application version.

The JVM implementation was returning null; this PR adds robust version retrieval from the JAR manifest's `Implementation-Version` or a generated `version.properties` file as a fallback.

---
<p><a href="https://cursor.com/agents/bc-74d57e79-dc1f-4881-89a3-b55cf71c5c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74d57e79-dc1f-4881-89a3-b55cf71c5c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->