### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/kmp.yml
+++ b/.github/workflows/kmp.yml
@@ -1,5 +1,8 @@
 name: Kotlin Multiplatform CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/softartdev/NoteDelight/security/code-scanning/5](https://github.com/softartdev/NoteDelight/security/code-scanning/5)

Add an explicit `permissions` block to `.github/workflows/kmp.yml` at the workflow root so it applies to both jobs. The least-privilege baseline here is:

- `contents: read`

This preserves current behavior for checkout/build/test/cache/artifact steps while documenting token scope and preventing accidental broader access if repo/org defaults change.

Edit region: near the top of the file, after `name:` and before `on:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
