### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/kmp.yml
+++ b/.github/workflows/kmp.yml
@@ -8,6 +8,9 @@ on:
       - '**'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build_job:
     name: Build (Unit-tests & Android-Lint)


### PR DESCRIPTION
Potential fix for [https://github.com/softartdev/NoteDelight/security/code-scanning/4](https://github.com/softartdev/NoteDelight/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/kmp.yml` so all jobs inherit restricted token access by default.  
Best single fix without changing behavior: add:

```yml
permissions:
  contents: read
```

near the top of the workflow (after `on:` block and before `jobs:`). This satisfies CodeQL’s recommendation and enforces minimum repo-content read access for actions like checkout. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
