### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - desktop/*
 
+permissions:
+  contents: write
+  packages: read
+
 jobs:
   build_job:
     name: Package


### PR DESCRIPTION
Potential fix for [https://github.com/softartdev/NoteDelight/security/code-scanning/3](https://github.com/softartdev/NoteDelight/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/desktop.yaml` to enforce least privilege.

Best fix here: define permissions at the workflow root (applies to all jobs), with:
- `contents: write` (required for creating/uploading release assets in `softprops/action-gh-release`)
- `packages: read` (safe minimal read scope often needed by build tooling; also aligns with CodeQL guidance about explicit read defaults)

This preserves existing functionality while making token privileges explicit and stable across repo/org setting changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
