### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - android/*
 
+permissions:
+  contents: read
+
 jobs:
   build_unit_test_publish_job:
     name: Build -> Unit-test -> Publish


### PR DESCRIPTION
Potential fix for [https://github.com/softartdev/NoteDelight/security/code-scanning/2](https://github.com/softartdev/NoteDelight/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/android.yml` to restrict `GITHUB_TOKEN` to the least privilege needed.  
Best single fix here is to define permissions at the workflow root so it applies to all jobs consistently (current file has one job, but this is safer for future additions). Start with:

- `contents: read` (minimal recommended baseline)

This does not change workflow functionality for the shown steps and satisfies CodeQL’s requirement for explicit token scoping.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
