### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,5 +1,8 @@
 name: iOS CD
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/softartdev/NoteDelight/security/code-scanning/1](https://github.com/softartdev/NoteDelight/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ios.yml` at the workflow root (top-level, alongside `name` and `on`) so it applies to all jobs unless overridden. The minimal safe setting from CodeQL guidance is:

- `contents: read`

This preserves current behavior for checkout and typical read operations while ensuring the token is not implicitly granted broader rights. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
